### PR TITLE
delete legacy rollup config

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -59,16 +59,6 @@ function configure(pkg, env, target) {
       // https://github.com/rollup/rollup-plugin-commonjs#custom-named-exports
       namedExports: {
         esrever: ['reverse'],
-
-        immutable: [
-          'List',
-          'Map',
-          'Record',
-          'OrderedSet',
-          'Set',
-          'Stack',
-          'is',
-        ],
         'react-dom': ['findDOMNode'],
         'react-dom/server': ['renderToStaticMarkup'],
       },


### PR DESCRIPTION
Just delete immtuable config in rollup. It's useless.